### PR TITLE
Trying to get plugin working again with VLC 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ build/
 .idea/
 contribs/include
 contribs/lib
+Makefile
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+libhtsp_plugin.so

--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@ between http (vlc) and htsp (kodi) streaming I decided to pursue this project.
 
 Thank you, BtbN for the awesome work so far.
 
+## Building & Installation
+
+The following steps were tested with Ubuntu 20.04 LTS focal.
+
+**1. Install required dependencies**
+
+    sudo apt install cmake libvlccore-dev
+
+**2. Build plugin**
+
+    cmake .
+    make
+
+On successful build you should find a `libhtsp_plugin.so` in the root directory.
+
+**3. Install the plugin (system-wide)**
+
+    sudo install -t /usr/lib/x86_64-linux-gnu/vlc/plugins/ --group root --owner root libhtsp_plugin.so
+
+After that, you should be able to
+
+* spot a _Tvheadend HTSP_ entry in the Playlist view in the _Local Network_ node
+* be able to configure your HTSP source in the VLC preferences view (Show settings: All) at _Input / Codec > Access modules > HTSP Protocol_
+
+
+
 -------------------------------------
 ## Legacy Notes.
 

--- a/access.cpp
+++ b/access.cpp
@@ -80,7 +80,11 @@ struct demux_sys_t : public sys_common_t
         ,hadIFrame(false)
         ,drops(0)
         ,epg(0)
+#if CHECK_VLC_VERSION(3,0)
+        ,thread({0})
+#else
         ,thread(0)
+#endif
         ,requestSpeed(INT_MIN)
         ,requestSeek(-1)
         ,doDisable(false)
@@ -460,11 +464,19 @@ void CloseHTSP(vlc_object_t *obj)
     if(!sys)
         return;
 
+#if CHECK_VLC_VERSION(3, 0)
+    if(sys->thread.handle)
+#else
     if(sys->thread)
+#endif
     {
         vlc_cancel(sys->thread);
         vlc_join(sys->thread, 0);
+#if CHECK_VLC_VERSION(3, 0)
+        sys->thread.handle = 0;
+#else
         sys->thread = 0;
+#endif
     }
 
     delete sys;

--- a/access.cpp
+++ b/access.cpp
@@ -367,7 +367,8 @@ bool SubscribeHTSP(demux_t *demux)
 bool parseURL(demux_t *demux)
 {
     demux_sys_t *sys = demux->p_sys;
-    const char *path = demux->psz_location;
+    char path[1024];
+    snprintf(path, sizeof(path), "%s://%s", demux->psz_access, demux->psz_location);
 
     if(path == 0 || *path == 0)
         return false;

--- a/access.cpp
+++ b/access.cpp
@@ -369,7 +369,11 @@ bool parseURL(demux_t *demux)
         return false;
 
     vlc_url_t *url = &(sys->url);
+#if CHECK_VLC_VERSION(3, 0)
+    vlc_UrlParse(url, path);
+#else
     vlc_UrlParse(url, path, 0);
+#endif
 
     if(url->psz_host == 0 || *url->psz_host == 0)
         return false;

--- a/discovery.cpp
+++ b/discovery.cpp
@@ -256,7 +256,11 @@ bool GetChannels(services_discovery_t *sd)
 
         input_item_SetArtworkURL(ch.item, ch.cicon.c_str());
 
+#if CHECK_VLC_VERSION(3, 0)
+        ch.item->i_type = ITEM_TYPE_STREAM;
+#else
         ch.item->i_type = ITEM_TYPE_NET;
+#endif
         for(std::string tag: ch.tags)
             services_discovery_AddItem(sd, ch.item, tag.c_str());
 

--- a/discovery.cpp
+++ b/discovery.cpp
@@ -266,9 +266,17 @@ bool GetChannels(services_discovery_t *sd)
         ch.item->i_type = ITEM_TYPE_NET;
 #endif
         for(std::string tag: ch.tags)
+#if CHECK_VLC_VERSION(3, 0)
+            services_discovery_AddItemCat(sd, ch.item, tag.c_str());
+#else
             services_discovery_AddItem(sd, ch.item, tag.c_str());
+#endif
 
+#if CHECK_VLC_VERSION(3, 0)
+        services_discovery_AddItemCat(sd, ch.item, "All Channels");
+#else
         services_discovery_AddItem(sd, ch.item, "All Channels");
+#endif
 
 
         sys->channelMap[ch.cid] = ch;

--- a/discovery.cpp
+++ b/discovery.cpp
@@ -46,7 +46,11 @@ struct tmp_channel
 struct services_discovery_sys_t : public sys_common_t
 {
     services_discovery_sys_t()
+#if CHECK_VLC_VERSION(3, 0)
+        :thread({0})
+#else
         :thread(0)
+#endif
         ,disconnect(false)
     {}
 
@@ -331,11 +335,19 @@ void CloseSD(vlc_object_t *obj)
     if(!sys)
         return;
 
+#if CHECK_VLC_VERSION(3, 0)
+    if(sys->thread.handle)
+#else
     if(sys->thread)
+#endif
     {
         vlc_cancel(sys->thread);
         vlc_join(sys->thread, 0);
+#if CHECK_VLC_VERSION(3, 0)
+        sys->thread.handle = 0;
+#else
         sys->thread = 0;
+#endif
     }
 
     delete sys;

--- a/helper.cpp
+++ b/helper.cpp
@@ -58,7 +58,11 @@ bool TransmitMessageEx(vlc_object_t *obj, sys_common_t *sys, HtsMessage m)
         return false;
     }
 
+#if CHECK_VLC_VERSION(3, 0)
+    if(net_Write(obj, sys->netfd, buf, len) != (ssize_t)len)
+#else
     if(net_Write(obj, sys->netfd, NULL, buf, len) != (ssize_t)len)
+#endif
     {
         msg_Dbg(obj, "net_Write failed");
         return false;
@@ -88,7 +92,11 @@ HtsMessage ReadMessageEx(vlc_object_t *obj, sys_common_t *sys)
         return HtsMessage();
     }
 
+#if CHECK_VLC_VERSION(3, 0)
+    if((readSize = net_Read(obj, sys->netfd, &len, sizeof(len))) != sizeof(len))
+#else
     if((readSize = net_Read(obj, sys->netfd, NULL, &len, sizeof(len), true)) != sizeof(len))
+#endif
     {
         net_Close(sys->netfd);
         sys->netfd = -1;
@@ -114,7 +122,11 @@ HtsMessage ReadMessageEx(vlc_object_t *obj, sys_common_t *sys)
 
     buf = (char*)malloc(len);
 
+#if CHECK_VLC_VERSION(3, 0)
+    if((readSize = net_Read(obj, sys->netfd, buf, len)) != (ssize_t)len)
+#else
     if((readSize = net_Read(obj, sys->netfd, NULL, buf, len, true)) != (ssize_t)len)
+#endif
     {
         net_Close(sys->netfd);
         sys->netfd = -1;

--- a/htsmessage.cpp
+++ b/htsmessage.cpp
@@ -428,7 +428,7 @@ HtsMessage HtsMessage::Deserialize(uint32_t length, void *buf)
 bool HtsMessage::Serialize(uint32_t *length, void **buf)
 {
     unsigned char *resBuf = 0;
-    uint32_t resLength = 4;
+    uint32_t resLength = 0;
     *length = 0;
     *buf = 0;
 


### PR DESCRIPTION
Annoyed by the webinterface & plalylist experience, I'm trying to resurect this plugin.

I started to update the build documentation and later on realized that for VLC 3.0 further code changes are necessary.

I merged @swegener `vlc-3. 0` branch from https://github.com/swegener/vlc-htsp-plugin/tree/vlc-3.0 into develop, which now seems to compile and the plugin can be installed. Unfortunately the playlist view stays empty.

Any ideas, @rado0x54 what might be missing?